### PR TITLE
Add initial scaffolding for must-tear-down-animations rule

### DIFF
--- a/lib/rules/must-tear-down-animations.js
+++ b/lib/rules/must-tear-down-animations.js
@@ -1,0 +1,33 @@
+/**
+ * Attempts to enforce that animations are torn down when component unmounts.
+ */
+
+const create = (context) => {
+
+    /**
+     * Report teardown violations (animations that are set but not
+     * torn down in componentWillUnmount)
+     */
+    function reportMissingTeardowns(errorNodes) {
+        // Iterate through all nodes failing the lint rule
+        // and use context.report to surface error to user.
+        errorNodes.forEach(node => {
+            context.report({
+                node: node,
+                message: 'Must tear down animation on unmount',
+            });
+        });
+    }
+    // List where we will accumulate nodes violating the rule.
+    const errorNodes = [];
+    return {
+
+        'Program:exit': () => {
+            reportMissingTeardowns(errorNodes);
+        }
+    };
+};
+
+module.exports = {
+    create,
+}


### PR DESCRIPTION
Wires up the basic structure of a eslint rule. Note: no actual logic for detecting violations! errorNodes is always an empty list, to this linter is very permissive at the moment :)

Test Plan:
The rule doesn't do anything yet. but when I combine with https://github.com/Khan/react-native-animation-linter/pull/2 and https://github.com/Khan/react-native-animation-linter/pull/1 we should be able to run `npm run test` successfully (though invalid cases fail the tests)