### PR TITLE
Handle variables when setting or initializing state

### DIFF
--- a/lib/rules/must-tear-down-animations.js
+++ b/lib/rules/must-tear-down-animations.js
@@ -5,7 +5,7 @@ const {astHelpers} = require('../util/animations');
 
 const create = (context) => {
 
-    // Stores all animated values that have been set.
+    // Stores all animated values that have been set (keyed by component)
     // When an animation is torn down, it is removed.
     const activeAnimations = {};
 
@@ -15,13 +15,15 @@ const create = (context) => {
      */
     function reportMissingTeardowns() {
         // Get list of all animated nodes that remain active (not torn down)
-        const activeNodes = Object.values(activeAnimations);
+        const componentAnimations = Object.values(activeAnimations);
         // Iterate through all nodes failing the lint rule
         // and use context.report to surface error to user.
-        activeNodes.forEach(node => {
-            context.report({
-                node: node,
-                message: `Must tear down animations when component unmounts`,
+        componentAnimations.forEach(activeNodes => {
+            Object.values(activeNodes).forEach(node => {
+                context.report({
+                    node: node,
+                    message: `Must tear down animations when component unmounts`,
+                });
             });
         });
     }
@@ -33,11 +35,14 @@ const create = (context) => {
     function checkAnimatedStateInitialization(node) {
         const stateProperty = _getStateInitialization(node);
         if (stateProperty) {
+            const componentId = _getParentComponentId(node)
             // If initializing state with an animation directly, record the animation
             const expression = node.value.callee;
             const isAnimation = astHelpers.isAnimationDeclaration(expression);
             if (isAnimation) {
-                activeAnimations[stateProperty] = node.value;
+                const componentAnimations = activeAnimations[componentId] || {};
+                componentAnimations[stateProperty] = node.value;
+                activeAnimations[componentId] = componentAnimations;
             }
         }
     }
@@ -49,13 +54,16 @@ const create = (context) => {
     function checkSetState(node) {
         const newState = _getStateUpdate(node);
         if (newState) {
+            const componentId = _getParentComponentId(node)
             newState.properties.forEach(p => {
                 const stateProperty = p.key.name;
                 const value = p.value;
                 // If setting state to an animation directly, record the animation
                 const isAnimation = astHelpers.isAnimationDeclaration(value.callee);
                 if (isAnimation) {
-                    activeAnimations[stateProperty] = value;
+                    const componentAnimations = activeAnimations[componentId] || {};
+                    componentAnimations[stateProperty] = value;
+                    activeAnimations[componentId] = componentAnimations;
                 }
             })
         }
@@ -114,14 +122,53 @@ const create = (context) => {
             return;
         }
         const statements = node.value.body.body;
+        const componentId = _getParentComponentId(node)
         statements.forEach(statement => {
             const isTeardown = astHelpers.isAnimationTeardown(statement)
             if (isTeardown) {
                 const propertyName = astHelpers.getTornDownAnimationState(
                     statement);
-                delete activeAnimations[propertyName];
+                const componentAnimations = activeAnimations[componentId];
+                if (componentAnimations) {
+                    delete activeAnimations[componentId][propertyName];
+                }
             }
         });
+    }
+
+    /**
+     * Traverse up the tree to find the parent component
+     */
+    function _getParentComponent(node) {
+        let currNode = node;
+        while (currNode) {
+            // Handle ES6 class syntax
+            if (currNode.type === 'ClassDeclaration') {
+                return currNode;
+            }
+            // Handle React.createClass syntax
+            if (currNode.type === "CallExpression" && currNode.callee) {
+                const expression = currNode.callee;
+                if (expression.object.name === "React" &&
+                    expression.property.name === "createClass") {
+                    return currNode.parent;
+                }
+            }
+            currNode = currNode.parent;
+        }
+    }
+
+    // Traverse up the tree to find parent component's ID
+    function _getParentComponentId(node) {
+        const component = _getParentComponent(node);
+        return getComponentId(component)
+    }
+
+    // Return a unique identifer for the provided react component.
+    function getComponentId(node) {;
+        const componentName = node.id.name;
+        const {start, end} = node;
+        return `${componentName}:${start}:${end}`
     }
 
     return {

--- a/lib/rules/must-tear-down-animations.js
+++ b/lib/rules/must-tear-down-animations.js
@@ -32,17 +32,29 @@ const create = (context) => {
      * Check state initialization. If state is set to an animated value
      * directly we record the animation.
      */
-    function checkAnimatedStateInitialization(node) {
+    function checkAnimatedStateInitialization(node, componentAnimations) {
         const stateProperty = _getStateInitialization(node);
         if (stateProperty) {
             const componentId = _getParentComponentId(node)
+            const componentAnimations = activeAnimations[componentId] || {};
             // If initializing state with an animation directly, record the animation
             const expression = node.value.callee;
             const isAnimation = astHelpers.isAnimationDeclaration(expression);
             if (isAnimation) {
-                const componentAnimations = activeAnimations[componentId] || {};
-                componentAnimations[stateProperty] = node.value;
-                activeAnimations[componentId] = componentAnimations;
+                _updateAnimationRecord(node, stateProperty)
+            } else if (node.value.type === "Identifier") {
+                const allVariablesInScope = context.getScope().variables;
+                // If we're setting state to a variable, check the current scope
+                // to determine if that variable has been set to an animated value.
+                allVariablesInScope.forEach(variable => {
+                    if (variable.name !== node.value.name) {
+                        return;
+                    }
+                    const isAnimatedState = _checkIsStateVariableAnimated(variable);
+                    if (isAnimatedState) {
+                        _updateAnimationRecord(node, stateProperty)
+                    }
+                });
             }
         }
     }
@@ -54,19 +66,46 @@ const create = (context) => {
     function checkSetState(node) {
         const newState = _getStateUpdate(node);
         if (newState) {
-            const componentId = _getParentComponentId(node)
             newState.properties.forEach(p => {
                 const stateProperty = p.key.name;
                 const value = p.value;
                 // If setting state to an animation directly, record the animation
                 const isAnimation = astHelpers.isAnimationDeclaration(value.callee);
                 if (isAnimation) {
-                    const componentAnimations = activeAnimations[componentId] || {};
-                    componentAnimations[stateProperty] = value;
-                    activeAnimations[componentId] = componentAnimations;
+                    _updateAnimationRecord(node, stateProperty)
+                } else if (p.value.type === "Identifier") {
+                    const allVariablesInScope = context.getScope().variables;
+                    allVariablesInScope.forEach(variable => {
+                        if (variable.name !== p.value.name) {
+                            return;
+                        }
+                        const isAnimatedState = _checkIsStateVariableAnimated(variable);
+                        if (isAnimatedState) {
+                            _updateAnimationRecord(node, stateProperty)
+                        }
+                    });
                 }
             })
         }
+    }
+
+    // Given a variable in scope, check if that variable is set to an
+    // animated value at any point. (note: we don't handle the case where
+    // a variable is set to an animated value but then overwritten)
+    function _checkIsStateVariableAnimated(variable) {
+        let isAnimated = false;
+        variable.references.forEach(r => {
+            // If we aren't setting the variable, skip this reference,
+            // since we know it isn't setting to an animated value.
+            if (!r.writeExpr) {
+                return;
+            }
+            if (astHelpers.isAnimationDeclaration(r.writeExpr.callee)) {
+                isAnimated = true;
+            }
+        });
+
+        return isAnimated;
     }
 
     /**
@@ -79,6 +118,16 @@ const create = (context) => {
             // We assume the first argument to setState is the new state;
             return node.arguments[0];
         }
+    }
+
+    /**
+     * Record a state object property as an animation in activeAnimations.
+     */
+    function _updateAnimationRecord(node, stateProperty) {
+        const componentId = _getParentComponentId(node);
+        const componentAnimations = activeAnimations[componentId] || {};
+        componentAnimations[stateProperty] = node;
+        activeAnimations[componentId] = componentAnimations;
     }
 
 

--- a/lib/rules/must-tear-down-animations.js
+++ b/lib/rules/must-tear-down-animations.js
@@ -5,10 +5,6 @@ const {astHelpers} = require('../util/animations');
 
 const create = (context) => {
 
-    // TODO(amy): express this in a way where names are scoped
-    // within a single component to handle multi-component cases.
-    // Using a flat object temporarily to get the simplest cases covered.
-
     // Stores all animated values that have been set.
     // When an animation is torn down, it is removed.
     const activeAnimations = {};

--- a/tests/lib/rules/must-tear-down-animations.js
+++ b/tests/lib/rules/must-tear-down-animations.js
@@ -408,23 +408,23 @@ const tests = {
         {
             // Multi-component case (only one of the animations is torn down)
             code: `
-                const React = require('react');
-                const {Animated} = require('react-native');
-                class MyComponent extends React.Component {
-                    state = {
-                        color: new Animated.Value(0)
-                    }
-                    componentWillUnmount() {
-                        this.state.color.stopAnimation();
-                    }
-                    render() {
-                        return <Animated.View/>;
-                    }
+            const React = require('react');
+            const {Animated} = require('react-native');
+            class MyComponent extends React.Component {
+                state = {
+                    color: new Animated.Value(0)
                 }
-                export default class MyOtherComponent extends React.Component {
+                render() {
+                    return <Animated.View/>;
+                }
+            }
+            export default class MyOtherComponent extends React.Component {
                 state = {
                     color: new Animated.Value(0),
                 };
+                componentWillUnmount() {
+                    this.state.color.stopAnimation();
+                }
                 render() {
                     return <Animated.View/>;
                 }


### PR DESCRIPTION
Previously we only handled cases where the animated value was set to state directly (e.g. state = { color: new Animated.Value(0)}). Now we handle the case where a variable is set to an animated value, and that variable is then used to set state. We do this by iterating through every variable that we set to state, and checking if it was ever set to an Animated.Value instance (within the current scope)

Test Plan:
confirm various tests that previously failed now pass (specifically, test cases that involve setting a variable to Animated.Value(0) and then setting state with that variable... previously that wasn't detected as an animation, now it is)