### PR TITLE
Handle a tricky import case

### DIFF
--- a/lib/rules/must-tear-down-animations.js
+++ b/lib/rules/must-tear-down-animations.js
@@ -5,6 +5,10 @@ const {astHelpers} = require('../util/animations');
 
 const create = (context) => {
 
+    // If we imported Animated from somewhere other than "react-native", all
+    // bets are off
+    let unexpectedImport = false;
+
     // Stores all animated values that have been set (keyed by component)
     // When an animation is torn down, it is removed.
     const activeAnimations = {};
@@ -14,6 +18,11 @@ const create = (context) => {
      * torn down in componentWillUnmount)
      */
     function reportMissingTeardowns() {
+        // If we've determined that Animated isn't actually from react-native,
+        // we ignore all detected "violations".
+        if (unexpectedImport) {
+            return;
+        }
         // Get list of all animated nodes that remain active (not torn down)
         const componentAnimations = Object.values(activeAnimations);
         // Iterate through all nodes failing the lint rule
@@ -220,6 +229,39 @@ const create = (context) => {
         return `${componentName}:${start}:${end}`
     }
 
+    // Detect if Animated is imported from an unusual source (not
+    // react-native) via a require import
+    function isReactNativeAnimationRequireImport(node) {
+        // extract left and right of a variable declaration like
+        // {Animated} = require('my-animation-library')
+        const left = node.id
+        const right = node.init;
+        if (left.type === "ObjectPattern") {
+            const propertyNames = left.properties.map(p => p.key.name);
+            if (propertyNames.indexOf("Animated") === -1) {
+                return;
+            }
+        }
+        if (left.type === "Identifier" && left.name != "Animated") {
+            return;
+        }
+        const requireImport = right.callee.name === "require";
+        const required = requireImport && right.arguments[0].value;
+        if (requireImport && required === "react-native") {
+            return;
+        }
+        unexpectedImport = true;
+    }
+
+    // Detect if Animated is imported from an unusual source (not
+    // react-native) via standard import syntax
+    function isReactNativeAnimationImport(node) {
+        if (node.specifiers[0].local.name === "Animated" &&
+            node.source.value !== "react-native") {
+            unexpectedImport = true;
+        }
+    }
+
     return {
 
         MethodDefinition: (node) => {
@@ -237,6 +279,14 @@ const create = (context) => {
         CallExpression: (node) => {
             // Animation state can also be set via setState
             checkSetState(node);
+        },
+
+        VariableDeclarator: (node) => {
+            isReactNativeAnimationRequireImport(node);
+        },
+
+        ImportDeclaration: (node) => {
+            isReactNativeAnimationImport(node);
         },
 
         'Program:exit': () => {

--- a/tests/lib/rules/must-tear-down-animations.js
+++ b/tests/lib/rules/must-tear-down-animations.js
@@ -161,7 +161,7 @@ const tests = {
         },
         {
             // Animated is imported from something sneaky, not react-native.
-            // It's okay that we don't tear it down!
+            // It's okay that we don't tear it down! (import style v1)
             code: `
             const React = require('react');
             const {Animated} = require('my-animation-library');
@@ -174,6 +174,38 @@ const tests = {
                     return <Animated.View/>;
                 }
            }`,
+        },
+        {
+            // Animated is imported from something sneaky, not react-native.
+            // It's okay that we don't tear it down! (import style v2)
+            code: `
+            const React = require('react');
+            const Animated = require('my-animation-library');
+            export default class MyComponent extends React.Component {
+                state = {
+                    color: new Animated.Value(0),
+                    height: 100,
+                };
+                render() {
+                    return <Animated.View/>;
+                }
+            }`,
+        },
+        {
+            // Animated is imported from something sneaky, not react-native.
+            // It's okay that we don't tear it down! (import style v3)
+            code: `
+            const React = require('react');
+            import Animated from 'my-animation-library';
+            export default class MyComponent extends React.Component {
+                state = {
+                    color: new Animated.Value(0),
+                    height: 100,
+                };
+                render() {
+                    return <Animated.View/>;
+                }
+            }`,
         },
         {
             // Animated state is extracted from state before torn down.


### PR DESCRIPTION
There's the sneaky possibility that the user calls `Animated.Value` on something that's not actually the Animate from react-native. Here were ensure that we're dealing with the expected `Animated` within the file. If we aren't, we don't have any idea what `Animated.Value` actually is, so we ignore all other validation!

Test Plan:
confirm all three sneaky import tests pass (2 tests newly added for more coverage of import options)