### PR TITLE
Handle case where state is extracted to variable before torn down

### DIFF
--- a/lib/rules/must-tear-down-animations.js
+++ b/lib/rules/must-tear-down-animations.js
@@ -45,6 +45,7 @@ const create = (context) => {
         const stateProperty = _getStateInitialization(node);
         if (stateProperty) {
             const componentId = _getParentComponentId(node)
+            const componentAnimations = activeAnimations[componentId] || {};
             // If initializing state with an animation directly, record the animation
             const expression = node.value.callee;
             const isAnimation = astHelpers.isAnimationDeclaration(expression);
@@ -74,7 +75,6 @@ const create = (context) => {
     function checkSetState(node) {
         const newState = _getStateUpdate(node);
         if (newState) {
-            const componentId = _getParentComponentId(node)
             newState.properties.forEach(p => {
                 const stateProperty = p.key.name;
                 const value = p.value;

--- a/lib/rules/must-tear-down-animations.js
+++ b/lib/rules/must-tear-down-animations.js
@@ -180,18 +180,58 @@ const create = (context) => {
             return;
         }
         const statements = node.value.body.body;
+        const stateVariables = {};
         const componentId = _getParentComponentId(node)
         statements.forEach(statement => {
             const isTeardown = astHelpers.isAnimationTeardown(statement)
+            const extractedState = _getStateExtraction(statement, stateVariables);
+            if (extractedState) {
+                stateVariables[extractedState.variable] = extractedState.property;
+            }
             if (isTeardown) {
-                const propertyName = astHelpers.getTornDownAnimationState(
+                const statePropertyName = astHelpers.getTornDownAnimationState(
                     statement);
-                const componentAnimations = activeAnimations[componentId];
-                if (componentAnimations) {
-                    delete activeAnimations[componentId][propertyName];
+                // If we're directly tearing down from a state reference
+                // (e.g. this.state.foo.stopAnimation(), mark it directly.
+                if (statePropertyName) {
+                    const componentAnimations = activeAnimations[componentId];
+                    if (componentAnimations) {
+                        delete activeAnimations[componentId][statePropertyName];
+                    }
+                } else {
+                    // Otherwise, trace the variable to determine if it
+                    // corresponds to any of the variables extracted from state
+                    const torndownVariable = statement.expression.callee.object;
+                    const stateMatch = stateVariables[torndownVariable.name]
+                    if (torndownVariable.type === "Identifier" && stateMatch) {
+                        const componentAnimations = activeAnimations[componentId];
+                        if (componentAnimations) {
+                            delete activeAnimations[componentId][stateMatch];
+                        }
+                    }
                 }
             }
         });
+    }
+
+    // Aggregate cases where state is extracted into variables.
+    // Can take the form of either const {color} = this.state;
+    // or const hue = this.state.color;
+    function _getStateExtraction(statement, stateVariables) {
+        if (statement.type === "VariableDeclaration") {
+            statement.declarations.forEach(declaration => {
+                // Handle `const {color} = this.state;` case
+                if (declaration.id.type === "ObjectPattern") {
+                    declaration.id.properties.forEach(prop => {
+                        stateVariables[prop.key.name] = prop.key.name;
+                    })
+                // Handle `const hue = this.state.color;` case
+                } else if (declaration.id.type === "Identifier") {
+                    const propertyName = declaration.init.property.name;
+                    stateVariables[declaration.id.name] = propertyName;
+                }
+            });
+        }
     }
 
     /**

--- a/tests/lib/rules/must-tear-down-animations.js
+++ b/tests/lib/rules/must-tear-down-animations.js
@@ -226,6 +226,24 @@ const tests = {
             }`,
         },
         {
+            // Animated state is extracted from state before torn down.
+            code: `
+            const React = require('react');
+            const {Animated} = require('react-native');
+            export default class MyComponent extends React.Component {
+                state = {
+                    color: new Animated.Value(0),
+                };
+                componentWillUnmount() {
+                    const mysteryVar = this.state.color;
+                    mysteryVar.stopAnimation();
+                }
+                render() {
+                    return <Animated.View/>;
+                }
+            }`,
+        },
+        {
             // Multi-component case (both components have animations torn down)
             code: `
             const React = require('react');


### PR DESCRIPTION
We previously weren't handling the case where, instead of calling `this.state.foo.stopAnimation()`, we first extract the state as a variable and then call stopAnimation on that variable. Now we keep track of every variable we've extracted from the state and then check for matches when we teardown.

I also add another test case to make sure we handle the two most common ways of extracting the state into a variable.

Test Plan:
confirm we now properly detect teardowns even if the animated variable is first extracted from the state and then torn down (2 new test cases pass)